### PR TITLE
[reactivesocket-tck] Remove subscription, remove shouldPass/shouldFail

### DIFF
--- a/src/main/scala/io/reactivesocket/tck/Reflection.scala
+++ b/src/main/scala/io/reactivesocket/tck/Reflection.scala
@@ -27,7 +27,6 @@ object RequesterReflection extends RequesterDSL {
         val test : Test = method.getDeclaredAnnotations()(0).asInstanceOf[Test]
         begintest()
         nametest(method.getName)
-        if (test.pass()) pass else fail
         method.invoke(cls)
       }
     }

--- a/src/main/scala/io/reactivesocket/tck/RequesterDSL.scala
+++ b/src/main/scala/io/reactivesocket/tck/RequesterDSL.scala
@@ -32,9 +32,6 @@ class RequesterDSL {
   def firenForget(data: String, metadata: String) : DSLTestSubscriber =
     new DSLTestSubscriber(writer, data, metadata, "fnf")
 
-  def requestSubscription(data: String, metadata: String) : DSLTestSubscriber =
-    new DSLTestSubscriber(writer, data, metadata, "sub")
-
   def end() : Unit = {
     writer.write("EOF\n")
     writer.close()
@@ -77,9 +74,5 @@ class RequesterDSL {
   def respond(marble : String) : Unit = {
     writer.write("respond%%" + marble + "\n")
   }
-
-  def pass() : Unit = writer.write("pass\n")
-
-  def fail() : Unit = writer.write("fail\n")
 
 }

--- a/src/main/scala/io/reactivesocket/tck/ResponderDSL.scala
+++ b/src/main/scala/io/reactivesocket/tck/ResponderDSL.scala
@@ -94,13 +94,6 @@ class ResponderDSL {
     }
   }
 
-  object requestSubscription extends HandlerImpl {
-    override def handle(data: String, meta: String) : Handler = {
-      writer.write("sub%%" + data + "%%" + meta + "%%")
-      this
-    }
-  }
-
   object requestChannel extends ChannelHandler {
 
     override def shouldFail(): ChannelHandler = {

--- a/src/main/scala/io/reactivesocket/tck/SampleTests.scala
+++ b/src/main/scala/io/reactivesocket/tck/SampleTests.scala
@@ -19,63 +19,25 @@ object clienttest extends RequesterDSL {
   }
 
   @Test
-  def echoTest() : Unit = {
-    requestChannel using("e", "f") asFollows(() => {
-      respond("a")
-      val cs = channelSubscriber()
-      cs request(1)
-      cs awaitAtLeast (1)
-      cs request(10)
-      respond("abcdefghijkmlnopqrstuvwxyz")
-      cs awaitAtLeast (10)
-      cs request(20)
-
-    })
-  }
-
-  // example for testing channel
-  @Test
-  def channelTest() : Unit = {
-    requestChannel using("a", "b") asFollows(() => { // onChannelRequest
-      respond("-a-")
-      val s1 = channelSubscriber
-      s1 request 1
-      respond("-b-c-d-e-f-")
-      s1 awaitAtLeast(1)
-      s1 assertReceivedAtLeast 1
-      s1 assertReceived List(("x", "x"))
-      s1 request 2
-      respond("-g-h-i-j-k-")
-      s1 awaitAtLeast(4)
-      s1 request 4
-      s1 awaitAtLeast(7)
-      respond("|")
-      s1 awaitTerminal()
-      s1 assertCompleted()
-    })
-  }
-
-  @Test
-  def requestresponsePass() : Unit = {
+  def requestResponseTest1() : Unit = {
     val s1 = requestResponse("a", "b")
     s1 request 1
     s1 awaitTerminal()
     s1 assertCompleted()
   }
 
-  @Test(pass = false)
-  def requestresponseFail() : Unit = {
+  @Test
+  def requestResponseTest2() : Unit = {
     val s1 = requestResponse("c", "d")
     s1 request 1
     s1 awaitTerminal()
     s1 assertReceived List(("ding", "dong"))
     s1 assertCompleted()
-    s1 assertNotCompleted()
     s1 assertNoErrors()
   }
 
   @Test
-  def requestresponsePass2() : Unit = {
+  def requestResponseTest3() : Unit = {
     val s1 = requestResponse("e", "f")
     s1 request 1
     s1 awaitTerminal()
@@ -85,7 +47,7 @@ object clienttest extends RequesterDSL {
 
   // example for testing stream
   @Test
-  def streamTest() : Unit = {
+  def streamTest1() : Unit = {
     val s1 = requestStream("a", "b")
     s1 request 3
     //val s2 = requestStream("c", "d")
@@ -113,6 +75,54 @@ object clienttest extends RequesterDSL {
   }
 
   @Test
+  def streamTest3() : Unit = {
+    val s2 = requestStream("c", "d")
+    s2 request 5
+    s2 awaitAtLeast (5)
+    s2 awaitNoAdditionalEvents 5000
+    s2 cancel()
+    s2 assertCanceled()
+    s2 assertNoErrors()
+  }
+
+  @Test
+  def echoTest() : Unit = {
+    requestChannel using("e", "f") asFollows(() => {
+      respond("a")
+      val cs = channelSubscriber()
+      cs request(1)
+      cs awaitAtLeast (1)
+      cs request(10)
+      respond("abcdefghijkmlnopqrstuvwxyz")
+      cs awaitAtLeast (10)
+      cs request(20)
+
+    })
+  }
+
+  // example for testing channel
+  @Test
+  def channelTest1() : Unit = {
+    requestChannel using("a", "b") asFollows(() => { // onChannelRequest
+      respond("-a-")
+      val s1 = channelSubscriber
+      s1 request 1
+      respond("-b-c-d-e-f-")
+      s1 awaitAtLeast(1)
+      s1 assertReceivedAtLeast 1
+      s1 assertReceived List(("x", "x"))
+      s1 request 2
+      respond("-g-h-i-j-k-")
+      s1 awaitAtLeast(4)
+      s1 request 4
+      s1 awaitAtLeast(7)
+      respond("|")
+      s1 awaitTerminal()
+      s1 assertCompleted()
+    })
+  }
+
+  @Test
   def channelTest2() : Unit = {
     requestChannel using("c", "d") asFollows(() => { // onChannelRequest
       respond("-a-")
@@ -133,43 +143,6 @@ object clienttest extends RequesterDSL {
       s1 awaitNoAdditionalEvents 100
     })
   }
-
-  @Test(pass = false)
-  def streamTestFail() : Unit = {
-    val s2 = requestStream("c", "d")
-    s2 request 2
-    s2 awaitNoAdditionalEvents 5000
-    s2 awaitAtLeast (2)
-    s2 cancel()
-    s2 assertCanceled()
-    s2 assertNoErrors()
-  }
-
-  @Test
-  def subscriptionTest() : Unit = {
-    val s1 = requestSubscription("a", "b")
-    s1 request 5
-    s1 awaitAtLeast(5)
-    s1 assertNotCompleted()
-    s1 assertNoErrors()
-    val s2 = requestStream("a", "b")
-    s2 request 1
-    s2 awaitAtLeast (1)
-    s2 assertReceived List(("a", "b"))
-    s1 assertReceivedCount 5
-    s1 request 100
-    s2 assertNoErrors()
-    s2 assertNotCompleted()
-    s2 request 1
-    s2 awaitAtLeast (2)
-    s2 assertReceived List(("a", "b"), ("c", "d"))
-    s1 take 7 // 7 total
-    s1 assertReceivedAtLeast 7
-    s1 assertNotCompleted()
-    s1 assertCanceled()
-    s1 assertNoErrors()
-  }
-
 
 }
 
@@ -203,11 +176,6 @@ object servertest extends ResponderDSL {
       "---a-----b-----c-----d--e--f---|")
     requestStream handle("c", "d") using(Map("a" -> ("a", "b"), "b" -> ("c", "d"), "c" -> ("e", "f")),
       "---a-----b-----c-----d--e--f---|")
-  }
-
-  @Test
-  def handleRequestSubscription() : Unit = {
-    requestSubscription handle("a", "b") using("abcdefghijklmnop")
   }
 
   @Test


### PR DESCRIPTION
logic

Subscription type has been merged with Stream.  Remove subscription
references.

(pass = False) tests used to lead to ambiguity.  It isn't
straightforward to detect whether the failure is the one we are
expecting.  The same thing could be tested by (pass = True) by changing
the conditions.