### PR TITLE
TCK does not support fail test header option anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,11 @@ an IDE like Intellij to write these tests, the autocomplete feature should be ve
 but we will go into detail later on exactly how a driver would be able to parse this command.
 The tests we write will have the following general format
 ```scala
-@Test(pass = fail)
+@Test
 def testName() : Unit = {
   // test logic
 }
 ```
-Note that that `(pass = fail)` part of the test header is optional. This line is for asserting the outcome of the test,
-as there are some situations that users would want to write tests that will fail. The default behavior is `(pass = true)`
-so for most tests that assert correct behavior, this part of the annotation is not needed.
 
 ##### Request Commands
 

--- a/src/main/scala/io/reactivesocket/tck/ReactiveSocketCoreTests.scala
+++ b/src/main/scala/io/reactivesocket/tck/ReactiveSocketCoreTests.scala
@@ -28,13 +28,6 @@ object client extends RequesterDSL {
     s assertError()
   }
 
-  @Test(pass = false)
-  def requestResponseTimeoutFail() : Unit = {
-    val s = requestResponse("e", "f")
-    s request 1
-    s awaitTerminal()
-  }
-
   @Test
   def requestResponseCancel() : Unit = {
     val s = requestResponse("g", "h")
@@ -480,13 +473,13 @@ object client extends RequesterDSL {
     })
   }
 
-  @Test(pass = false)
+  @Test
   def requestResponseRequestAfterCancel(): Unit = {
     val s = requestResponse("request", "cancel")
     s cancel()
     s request 1
-    s awaitAtLeast 1
-    s assertReceivedCount 1
+    s awaitNoAdditionalEvents 2000
+    s assertReceivedCount 0
   }
 
   @Test
@@ -521,7 +514,7 @@ object client extends RequesterDSL {
     s4 cancel()
   }
 
-  @Test(pass = false)
+  @Test
   def requestStreamAfterCancel() : Unit = {
     val s = requestStream("after", "cancel")
     s request 1
@@ -530,7 +523,8 @@ object client extends RequesterDSL {
     s cancel()
     s assertCanceled()
     s request 1
-    s awaitAtLeast 2 // should timeout
+    s awaitNoAdditionalEvents 2000
+    s assertReceivedCount 1
   }
 
   @Test(pass = false)


### PR DESCRIPTION
TCK does not support fail test header option anymore.
- Removed the 'fail' option from RequestResponse and RequestStream Tests
- Rewrote the tests accordingly

Have not fixed Channel test yet. I will try to fix the channel test in the next commit 